### PR TITLE
fix: replaced id with environment variable

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,4 +1,4 @@
-export const GA_TRACKING_ID = 'G-6GQZ86MRWV'
+export const GA_TRACKING_ID = `${process.env.NEXT_PUBLIC_ANALYTICS_ID}`
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url) => {


### PR DESCRIPTION
Replaced Google Analytic ID with an Environment Variable.

Previous Google Analytic ID has been invalidated due to exposure.