### PR TITLE
fix: correct wol samurai hp value

### DIFF
--- a/public/bossdata/data.json
+++ b/public/bossdata/data.json
@@ -1455,7 +1455,7 @@
         { "job": "mnk", "bossHp": "2601840" },
         { "job": "drg", "bossHp": "2625520" },
         { "job": "nin", "bossHp": "2554480" },
-        { "job": "sam", "bossHp": "27217200" },
+        { "job": "sam", "bossHp": "2721720" },
         { "job": "brd", "bossHp": "2304360" },
         { "job": "mch", "bossHp": "2604800" },
         { "job": "dnc", "bossHp": "1995040" },


### PR DESCRIPTION
The Warrior of Light HP Value for Samurai is

`27217200`

It should be

`2721720`